### PR TITLE
Add folder mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -313,6 +313,14 @@ With the `--postgrest` flag, `gtfs-via-postgres` will augment the schema with a 
 
 [read more](docs/postgrest.md)
 
+### Folder mode
+
+With the `--folder-mode` flag, a folder name can be used instead of a file wildcard. All files in the given directory will be read and used in the script. Unsupported files can be ignored using the `-u` flag.
+
+```
+npm exec -- gtfs-to-sql --folder-mode -- gtfs | sponge | psql -b
+```
+
 ### more guides
 
 The [`docs` directory](docs) contains more instructions on how to use `gtfs-via-postgres`.


### PR DESCRIPTION
Thanks for the script everyone. 

### Changes
I added a 'folder mode' argument that takes the argument and reads the given directory, then parses the files in it as normal, regardless of file extention.

### Why
I had it working on my work macbook (m3), however I was fooling around with it relentlessly on my personal PC (Windows + WSL2). I could not get it working for the life of me with the provided examples or while fooling around with the command.

### Does it work?
I tested it on my local windows machine using WSL2 ubuntu 22 with 'moreutils' (for sponge) and 'postgres' installed. Using node v22 I ran the script beneath which resulted in the proper output as I got on my macbook without folder mode.

```
node cli.js --folder-mode --stops-location-index --require-dependencies -u -- gtfs | sponge | psql -h localhost -p 5432 -b -U postgres
```
(folder in example script is ./gtfs including all gtfs.txt files)

